### PR TITLE
Better namespace for do-notation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ data Door : (a : Type) -> DoorState -> (a -> DoorState) -> Type
 which is no longer a functor or applicative (as far as I have been able to figure, without representing the second state transition function as a data type itself). This package surfaces `TransitionIndexedPointed` and `TransitionIndexedMonad` that suit this use-case. The `Pointed` interface declares a `pure` function and the `Monad` interface declares a `bind` function.
 
 I've also started to add other useful things in around the base monad extensions like an `IndexedStateT` type.
+
+### Disambiguating do-notation
+Not all do-statements cause trouble, but longer do-statements sometimes need to be disambiguated.
+
+If you need to disambiguate a do-statement that uses an indexed monad implementation, you can use:
+```idris
+Indexed.do
+  ...
+```
+in contrast to, say, a traditional monad:
+```idris
+Prelude.do
+  ...
+```

--- a/indexed.ipkg
+++ b/indexed.ipkg
@@ -1,6 +1,6 @@
 package indexed
 
-version = 0.0.8
+version = 0.0.9
 sourcedir = "src"
 
 modules = Control.Applicative.Indexed

--- a/src/Control/Monad/Indexed/Do.idr
+++ b/src/Control/Monad/Indexed/Do.idr
@@ -4,11 +4,12 @@ module Control.Monad.Indexed.Do
 
 import Control.Monad.Indexed
 
-public export
-(>>=) : IndexedMonad z m => m a i j -> (a -> m b j k) -> m b i k
-(>>=) = (>>>=)
+namespace Indexed
+  public export
+  (>>=) : IndexedMonad z m => m a i j -> (a -> m b j k) -> m b i k
+  (>>=) = (>>>=)
 
-public export
-(>>) : IndexedMonad z m => m () i j -> Lazy (m b j k) -> m b i k
-(>>) = (>>>)
+  public export
+  (>>) : IndexedMonad z m => m () i j -> Lazy (m b j k) -> m b i k
+  (>>) = (>>>)
 

--- a/src/Control/Monad/TransitionIndexed/Do.idr
+++ b/src/Control/Monad/TransitionIndexed/Do.idr
@@ -5,11 +5,12 @@ module Control.Monad.TransitionIndexed.Do
 
 import Control.Monad.TransitionIndexed
 
-public export
-(>>=) : TransitionIndexedMonad z m => m a x f -> ((res : a) -> m b (f res) g) -> m b x g
-(>>=) = (>>>=)
+namespace Indexed
+  public export
+  (>>=) : TransitionIndexedMonad z m => m a x f -> ((res : a) -> m b (f res) g) -> m b x g
+  (>>=) = (>>>=)
 
-public export
-(>>) : TransitionIndexedMonad z m => m () x f -> Lazy (m b (f ()) g) -> m b x g
-(>>) = (>>>)
+  public export
+  (>>) : TransitionIndexedMonad z m => m () x f -> Lazy (m b (f ()) g) -> m b x g
+  (>>) = (>>>)
 

--- a/src/Control/Monad/TransitionIndexed/Do.idr
+++ b/src/Control/Monad/TransitionIndexed/Do.idr
@@ -5,7 +5,7 @@ module Control.Monad.TransitionIndexed.Do
 
 import Control.Monad.TransitionIndexed
 
-namespace Indexed
+namespace TransitionIndexed
   public export
   (>>=) : TransitionIndexedMonad z m => m a x f -> ((res : a) -> m b (f res) g) -> m b x g
   (>>=) = (>>>=)


### PR DESCRIPTION
**Breaking:**
Code that used to disambiguate with `Indexed.Do.do` should now be changed to `Indexed.do`.