### PR TITLE
Fix warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
+      "inputs": {
+        "systems": "systems"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -48,18 +36,18 @@
     },
     "idris2": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "idris-emacs-src": "idris-emacs-src",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1673849241,
-        "narHash": "sha256-aVn5lZpn16778AZxa1iz4T2Wepcq+bwRDOfNiNK/3R8=",
+        "lastModified": 1726342435,
+        "narHash": "sha256-QmYLTnIdu7UkEy8ZVRYBUIBgsbX2fifWyO4ILlT0/bg=",
         "owner": "idris-lang",
         "repo": "Idris2",
-        "rev": "24ac56de8809ae7a2cd0126f01110d4b762389fc",
+        "rev": "09cb83dd97ccfaee921c7766d093092a6da55bc2",
         "type": "github"
       },
       "original": {
@@ -71,23 +59,39 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673606088,
-        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
-        "owner": "NixOS",
+        "lastModified": 1726206720,
+        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
+        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "idris2": "idris2",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           buildIdris = idris2.buildIdris.${system};
           indexedPkg = buildIdris {
             ipkgName = "indexed";
-            version = "0.0.9";
+            version = "0.0.10";
             src = ./.;
             idrisLibraries = [ ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -2,38 +2,38 @@
   description = "A little foundation around indexed interfaces for functor, applicative, and monad.";
 
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
     idris2 = {
       url = "github:idris-lang/Idris2/main";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, idris2 }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-          stdenv = pkgs.stdenv;
-          idris2' = idris2.defaultPackage.${system};
-      in {
-        packages.default = stdenv.mkDerivation rec {
-          name = "idris-indexed";
-          version = "0.0.9";
-          src = ./.;
-          idrisPackages = [];
-          buildInputs = [ idris2' ] ++ idrisPackages;
-
-          IDRIS2 = "${idris2'}/bin/idris2";
-          IDRIS2_PREFIX = "${placeholder "out"}";
-          IDRIS2_PACKAGE_PATH = builtins.concatStringsSep ":" (builtins.map (p: "${p}/idris2-${idris2'.version}") idrisPackages);
-
-          buildPhase = ''
-            make clean
-            make build
-          '';
-          installPhase = ''
-            make install
-          '';
-        };
-      }
-    );
+  outputs =
+    { nixpkgs, idris2, ... }:
+    let
+      inherit (nixpkgs) lib;
+      eachDefaultSystem = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      packages = eachDefaultSystem (
+        system:
+        let
+          buildIdris = idris2.buildIdris.${system};
+          indexedPkg = buildIdris {
+            ipkgName = "indexed";
+            version = "0.0.9";
+            src = ./.;
+            idrisLibraries = [ ];
+          };
+        in
+        rec {
+          indexed = indexedPkg.library { };
+          indexedWithSource = indexedPkg.library { withSource = true; };
+          default = indexed;
+        }
+      );
+      formatter = eachDefaultSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-rfc-style);
+    };
 }

--- a/indexed.ipkg
+++ b/indexed.ipkg
@@ -1,6 +1,8 @@
 package indexed
 
-version = 0.0.9
+version = 0.0.10
+langversion >= 0.7.0
+
 sourcedir = "src"
 
 modules = Control.Applicative.Indexed

--- a/src/Control/Applicative/Indexed.idr
+++ b/src/Control/Applicative/Indexed.idr
@@ -2,6 +2,7 @@ module Control.Applicative.Indexed
 
 import Control.Functor.Indexed
 
+export
 infixl 3 <<*>>, <<*, *>>
 
 public export

--- a/src/Control/Functor/Indexed.idr
+++ b/src/Control/Functor/Indexed.idr
@@ -1,6 +1,9 @@
 module Control.Functor.Indexed
 
+export
 infixl 1 <<&>>
+
+export
 infixr 4 <<$>>, <<$, $>>
 
 ||| An Indexed Functor.

--- a/src/Control/Monad/Indexed.idr
+++ b/src/Control/Monad/Indexed.idr
@@ -3,6 +3,7 @@ module Control.Monad.Indexed
 import Control.Functor.Indexed
 import Control.Applicative.Indexed
 
+export
 infixl 1 >>>=, =<<<, >>>, >>=>, <=<<
 
 public export

--- a/src/Control/Monad/TransitionIndexed.idr
+++ b/src/Control/Monad/TransitionIndexed.idr
@@ -1,5 +1,6 @@
 module Control.Monad.TransitionIndexed
 
+export
 infixl 1 >>>=, =<<<, >>>
 
 %hide Prelude.pure

--- a/tests/tests.ipkg
+++ b/tests/tests.ipkg
@@ -1,9 +1,9 @@
 package tests
 
 executable = "test"
-depends = indexed >= 0.0.7
-        , contrib >= 0.5.1
-        , test    >= 0.5.1
+depends = indexed >= 0.0.10
+        , contrib >= 0.7.0
+        , test    >= 0.7.0
 
 modules = Main
 main    = Main


### PR DESCRIPTION
Fix some compiler warnings introduced with the latest compiler version. Bump minimum language version as a result. Also update Nix flake to use buildIdris function to build the library.